### PR TITLE
Set default worker transfer ports for lpc; updated docs

### DIFF
--- a/docs/deployment/clusters/lpc.md
+++ b/docs/deployment/clusters/lpc.md
@@ -42,6 +42,8 @@ Set ports explicitly:
 floability run --backpack <backpack-root> --batch-type condor \
 	--manager-ports 10000,11000
 ```
+## Worker Transfer Ports
+The allowed ports for worker transfer is `10000:11000`. If the `--worker-transfer-ports` option is not specified, floability will default to the range `10000:11000` while on LPC.
 
 ## SSH Tunneling Note
 

--- a/floability/ops/run.py
+++ b/floability/ops/run.py
@@ -578,7 +578,6 @@ def _start_workers(
 
     print("[floability] worker factory startup")
     if args.worker_transfer_ports is None and "fnal.gov" in os.uname().nodename:
-        print(os.uname().nodename)
         args.worker_transfer_ports = "10000:11000"
     factory_proc = start_workers_for_instance(
         instance_path=ctx.root,

--- a/floability/ops/run.py
+++ b/floability/ops/run.py
@@ -563,7 +563,7 @@ def _send_catalog_event(
 
 def _start_workers(
     args: argparse.Namespace,
-    ctx: InstanceContext,
+    ctx: tanceContext,
     env_ctx: EnvironmentContext,
     cleanup_manager: CleanupManager,
 ) -> Optional[Any]:
@@ -577,7 +577,9 @@ def _start_workers(
         return None
 
     print("[floability] worker factory startup")
-
+    if args.worker_transfer_ports is None and "fnal.gov" in os.uname().nodename:
+        print(os.uname().nodename)
+        args.worker_transfer_ports = "10000:11000"
     factory_proc = start_workers_for_instance(
         instance_path=ctx.root,
         cli_args=args,

--- a/floability/ops/run.py
+++ b/floability/ops/run.py
@@ -563,7 +563,7 @@ def _send_catalog_event(
 
 def _start_workers(
     args: argparse.Namespace,
-    ctx: tanceContext,
+    ctx: InstanceContext,
     env_ctx: EnvironmentContext,
     cleanup_manager: CleanupManager,
 ) -> Optional[Any]:


### PR DESCRIPTION
This PR adds a method to specify a default worker transfer port range when floability is run at LPC (fnal.gov). This may be superseded by a more general method in PR#72