### PR TITLE
Automatic creation of backpack structure

### DIFF
--- a/docs/getting-started/create-first-backpack.md
+++ b/docs/getting-started/create-first-backpack.md
@@ -37,17 +37,90 @@ consistently everywhere — your laptop, a university cluster, or cloud.
 
 ## Creating a Backpack
 
-There are three ways to create a backpack, depending on what you already have:
+There are four ways to create a backpack, depending on what you already have:
 
-1. **Manual creation**: Write the directory structure and files yourself
-2. **From a template**: Start from a pre-built example notebook when you don't have existing code yet
-3. **From an existing workflow**: Automatically scaffold the backpack structure around your existing notebook or script
+1. **Automatic creation (audit)**: Run your existing notebook with dependency tracing to automatically generate the full backpack structure, including environment, data files, and compute configuration
+2. **Manual creation**: Write the directory structure and files yourself
+3. **From a template**: Start from a pre-built example notebook when you don't have existing code yet
+4. **From an existing workflow**: Automatically scaffold the backpack structure around your existing notebook or script
 
 In every case you will need to review and adjust the generated files to match
 your actual computation, dependencies, and resource requirements.
 
 
-### Option 1: Create a Backpack Manually
+### Option 1: Automatic Creation (Audit)
+
+The `floability audit` command runs your notebook with dependency tracing and automatically generates a complete backpack. It captures the software environment and data files your notebook accessed during execution.
+
+```bash
+floability audit \
+  --notebook my-analysis.ipynb \
+  --conda-env /path/to/my-conda-env \
+  --data-dirs ./data \
+  --backpack-name my-backpack
+```
+
+This creates:
+
+```
+my-backpack/
+├── compute/
+│   └── compute.yml
+├── software/
+│   └── environment.yml    # captured from your conda env
+├── workflow/
+│   └── my-analysis.ipynb
+└── data/
+    ├── data.yml           # generated from detected data files
+    └── <data files>       # copied from your data directory
+```
+
+#### Key flags
+
+| Flag | Description |
+|---|---|
+| `--notebook` | Path to the notebook to audit |
+| `--conda-env` | Conda environment prefix where the notebook runs |
+| `--data-dirs` | One or more directories containing input data files |
+| `--no-worker` | Skip vine worker (for non-distributed notebooks) |
+| `--backpack-name` | Name for the generated backpack directory |
+| `--force` | Overwrite existing backpack directory |
+
+#### Distributed workflows (TaskVine)
+
+For notebooks that use TaskVine:
+
+```bash
+floability audit \
+  --notebook cms-analysis.ipynb \
+  --conda-env /shared/envs/physics-env \
+  --data-dirs ./data \
+  --backpack-name cms-backpack
+```
+
+#### Non-distributed workflows
+
+For notebooks that do not use TaskVine, add `--no-worker`:
+
+```bash
+floability audit \
+  --notebook gis-analysis.ipynb \
+  --conda-env /shared/envs/gis-env \
+  --data-dirs ./data \
+  --no-worker \
+  --backpack-name gis-backpack
+```
+
+#### After running audit
+
+Review and adjust the generated files before running:
+
+- **`compute/compute.yml`**: Set worker count, cores, and memory for your workload
+- **`software/environment.yml`**: Verify all dependencies were captured correctly
+- **`data/data.yml`**: Update `source_type` and `source` paths if you plan to fetch data from a remote source (S3, Pelican, HTTP) rather than bundling files in the backpack
+
+
+### Option 2: Create a Backpack Manually
 
 Creating a backpack manually gives you full control. The required layout is:
 
@@ -102,7 +175,7 @@ Optionally add a `data/data.yml` if your workflow reads input files.
 See [Data Specification](../reference/data-spec.md) for the format.
 
 
-### Option 2: From a Template (Start from Scratch)
+### Option 3: From a Template (Start from Scratch)
 
 Use a template when you **don't have existing code** and want a working
 starter notebook to edit. The template demonstrates the TaskVine distributed
@@ -199,7 +272,7 @@ for file_path in files:
 This also creates a `data/data.yml` file where you specify input sources (S3, HTTP, local directory). See [Data Specification](../reference/data-spec.md) for configuration details.
 
 
-### Option 3: From an Existing Workflow
+### Option 4: From an Existing Workflow
 
 If you already have a notebook or script, the `--from-workflow` flag
 scaffolds the full backpack structure around it automatically.

--- a/floability/audit/audit.py
+++ b/floability/audit/audit.py
@@ -1,9 +1,13 @@
-import shutil
 import os
-import subprocess
+import shutil
 import signal
+import subprocess
 import time
+from pathlib import Path
+from typing import Dict, Optional
+
 import nbformat
+from jupyter_client.kernelspec import KernelSpecManager
 
 from floability.audit.generate_requirements import main as generate_requirements
 from floability.audit.generate_verified_env_yaml import (
@@ -11,11 +15,9 @@ from floability.audit.generate_verified_env_yaml import (
 )
 from floability.audit.generate_data_deps import main as generate_data_deps
 from floability.audit.log_data_deps import get_code_to_log_data_deps
-from jupyter_client.kernelspec import KernelSpecManager
 
 
 def update_notebook_kernel(notebook_path, kernel_name):
-    # Load available kernels
     ksm = KernelSpecManager()
     kernels = ksm.find_kernel_specs()
 
@@ -24,179 +26,202 @@ def update_notebook_kernel(notebook_path, kernel_name):
             f"Kernel '{kernel_name}' not found. Available kernels: {list(kernels.keys())}"
         )
 
-    # Load kernel spec info
     spec = ksm.get_kernel_spec(kernel_name)
 
-    # Load notebook
     with open(notebook_path, "r", encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
 
-    # Update metadata
     nb.metadata.kernelspec = {
         "name": kernel_name,
         "display_name": spec.display_name,
         "language": spec.language,
     }
 
-    # Save updated notebook
     with open(notebook_path, "w", encoding="utf-8") as f:
         nbformat.write(nb, f)
 
 
 def add_code_to_notebook(notebook_path, code):
-    """
-    Add code to the top of a Jupyter notebook.
-    """
+    """Add code to the top of a Jupyter notebook."""
     with open(notebook_path, "r") as f:
         nb = nbformat.read(f, as_version=4)
 
-    # Create a new code cell
     new_cell = nbformat.v4.new_code_cell(code)
-
-    # Insert the new cell at the beginning
     nb.cells.insert(0, new_cell)
 
-    # Write the modified notebook back to the file
     with open(notebook_path, "w") as f:
         nbformat.write(nb, f)
 
 
-def audit(notebook_path, kernel_name, manager_name, manager_port):
-    """
-    Main function to audit a Jupyter notebook for dependencies.
-    """
-    # Ensure the notebook path is absolute
+def _build_vine_worker_cmd(
+    strace_out: Path,
+    manager_name: Optional[str],
+    manager_port: Optional[str],
+    conda_env: Optional[str],
+) -> list:
+    """Build the strace-wrapped vine_worker command."""
+    strace_prefix = [
+        "strace", "-qqq", "-r", "-z", "-f",
+        "-o", str(strace_out),
+        "-e", "trace=openat,fstat,newfstatat",
+    ]
 
-    tmp_dir = os.getcwd() + "/tmp"
-    os.makedirs(tmp_dir, exist_ok=True)
+    if conda_env:
+        worker_cmd = ["conda", "run", "--prefix", conda_env, "--no-capture-output", "vine_worker", "localhost"]
+    else:
+        worker_cmd = ["vine_worker", "localhost"]
 
-    strace_worker = tmp_dir + "/strace_worker.txt"
-    strace_manager = tmp_dir + "/strace_manager.txt"
-    open_trace_log = tmp_dir + "/open_trace.log"
+    if manager_name:
+        worker_cmd += ["-M", manager_name]
+    else:
+        worker_cmd += [manager_port]
+
+    return strace_prefix + worker_cmd
+
+
+def audit(notebook_path, kernel_name, manager_name, manager_port, conda_env=None, data_dirs=None, no_worker=False) -> Dict[str, Path]:
+    """
+    Audit a Jupyter notebook for software and data dependencies.
+
+    Args:
+        notebook_path: Path to the Jupyter notebook to audit.
+        kernel_name: Kernel name to use (or None for notebook default).
+        manager_name: TaskVine manager name (or None to use manager_port).
+        manager_port: TaskVine manager port.
+        conda_env: Path to a conda environment prefix used to run both
+                   vine_worker and jupyter execute. When None, uses PATH.
+        data_dirs: List of directory paths (relative to notebook dir or absolute)
+                   containing data files. When provided, strace is scanned
+                   directly for files under those paths.
+
+    Returns a dict with paths to all generated output files:
+      - strace_manager: manager strace log
+      - strace_worker: worker strace log
+      - manager_environment_yml: manager_environment.yml
+      - worker_environment_yml: worker_environment.yml
+      - manager_data_dependencies_yml: manager_data_dependencies.yml
+      - worker_data_dependencies_yml: worker_data_dependencies.yml
+    """
+    cwd = Path.cwd()
+    tmp_dir = cwd / "tmp"
+    tmp_dir.mkdir(exist_ok=True)
+
+    strace_worker = tmp_dir / "strace_worker.txt"
+    strace_manager = tmp_dir / "strace_manager.txt"
+    open_trace_log = tmp_dir / "open_trace.log"
 
     notebook_path = notebook_path.strip()
     if kernel_name:
         kernel_name = kernel_name.strip()
-
     if manager_port:
         manager_port = manager_port.strip()
-
     if manager_name:
         manager_name = manager_name.strip()
 
-    notebook_name = notebook_path.split("/")[-1]
-    notebook_path_str = "/".join(notebook_path.split("/")[:-1])
-    if notebook_path_str != "":
-        notebook_copy_path = notebook_path_str + "/copy_" + notebook_name
-    else:
-        notebook_copy_path = "copy_" + notebook_name
+    notebook_dir = Path(notebook_path).resolve().parent
+    notebook_name = Path(notebook_path).name
+    notebook_copy_path = str(notebook_dir / f"copy_{notebook_name}")
+
     shutil.copy(notebook_path, notebook_copy_path)
     print("Created temp copy of the notebook: ", notebook_name)
 
-    # Add code to the top of the notebook to capture data dependencies
-    code_to_add = get_code_to_log_data_deps().replace("open_trace_log", open_trace_log)
-
+    code_to_add = get_code_to_log_data_deps().replace("open_trace_log", str(open_trace_log))
     add_code_to_notebook(notebook_copy_path, code_to_add)
     print("Added code to the top of the notebook.")
 
-    print("Starting vine workers with strace...")
     p_worker = None
-    if manager_name:
-        p_worker = subprocess.Popen(
-            [
-                "strace",
-                "-qqq",
-                "-r",
-                "-z",
-                "-f",
-                "-o",
-                strace_worker,
-                "-e",
-                "trace=openat,fstat,newfstatat",
-                "vine_worker",
-                "localhost",
-                "-M",
-                manager_name,
-            ],
-            start_new_session=True,
-        )
+    worker_pid = None
+    if not no_worker:
+        print("Starting vine workers with strace...")
+        worker_cmd = _build_vine_worker_cmd(strace_worker, manager_name, manager_port, conda_env)
+        p_worker = subprocess.Popen(worker_cmd, start_new_session=True)
+        worker_pid = p_worker.pid
+        print("worker_pid:", worker_pid)
     else:
-        p_worker = subprocess.Popen(
-            [
-                "strace",
-                "-qqq",
-                "-r",
-                "-z",
-                "-f",
-                "-o",
-                strace_worker,
-                "-e",
-                "trace=openat,fstat,newfstatat",
-                "vine_worker",
-                "localhost",
-                manager_port,
-            ],
-            start_new_session=True,
-        )
-    worker_pid = p_worker.pid
-    print("worker_pid:", worker_pid)
+        print("Skipping vine worker (--no-worker).")
 
     start = time.time()
-    # Execute the notebook in background using the specified kernel
 
     if kernel_name:
         try:
-            # update notebook kernel
             update_notebook_kernel(notebook_copy_path, kernel_name)
-        except ValueError as e:
+        except ValueError:
             print(f"Error updating notebook kernel: {kernel_name}")
-            return
+            return {}
 
     print("Starting the notebook with strace... ")
-    p_manager = subprocess.run(
+    if conda_env:
+        jupyter_cmd = [
+            "conda", "run", "--prefix", conda_env, "--no-capture-output",
+            "jupyter", "execute", notebook_copy_path,
+        ]
+        print(f"  Running notebook in conda env: {conda_env}")
+    else:
+        jupyter_cmd = ["jupyter", "execute", notebook_copy_path]
+
+    subprocess.run(
         [
             "strace",
-            "-qqq",
-            "-r",
-            "-z",
-            "-f",
-            "-o",
-            strace_manager,
-            "-e",
-            "trace=openat,fstat,newfstatat",
-            "jupyter",
-            "execute",
-            notebook_copy_path,
-        ]
+            "-qqq", "-r", "-z", "-f",
+            "-o", str(strace_manager),
+            "-e", "trace=openat,fstat,newfstatat",
+        ] + jupyter_cmd,
     )
     print("time taken to execute the notebook: ", time.time() - start)
 
-    # Remove the copied notebook
     os.remove(notebook_copy_path)
     print("Removed notebook copy.")
 
-    # Shutdown processes
-    os.killpg(os.getpgid(worker_pid), signal.SIGTERM)
-    print("Removed vine worker process tree.")
+    if worker_pid is not None:
+        os.killpg(os.getpgid(worker_pid), signal.SIGTERM)
+        print("Removed vine worker process tree.")
 
     start = time.time()
-    # Find the dependencies and generate YAML file
-    generate_requirements(strace_manager, strace_worker)
 
-    # Generate verified YAML files for worker and manager
+    generate_requirements(str(strace_manager), str(strace_worker), conda_env_prefix=conda_env)
+
+    manager_env_yml = cwd / "manager_environment.yml"
+    worker_env_yml = cwd / "worker_environment.yml"
+
     generate_verified_env_yaml(
-        "worker_requirements.txt", output="worker_environment.yml"
+        "worker_requirements.txt", output=str(worker_env_yml), conda_prefix=conda_env
     )
-
     generate_verified_env_yaml(
-        "manager_requirements.txt", output="manager_environment.yml"
+        "manager_requirements.txt", output=str(manager_env_yml), conda_prefix=conda_env
     )
 
     print("Generated verified YAML files for worker and manager.")
-
     print("time taken to generate verified YAML files: ", time.time() - start)
 
     start = time.time()
-    # Find data dependencies and generate TXT file
-    generate_data_deps(open_trace_log, strace_manager, strace_worker)
+
+    manager_data_deps_yml = cwd / "manager_data_dependencies.yml"
+    worker_data_deps_yml = cwd / "worker_data_dependencies.yml"
+
+    resolved_data_dirs = None
+    if data_dirs:
+        resolved_data_dirs = [
+            str((notebook_dir / d).resolve()) if not Path(d).is_absolute() else d
+            for d in data_dirs
+        ]
+        print(f"[floability] Scanning strace for data files under: {resolved_data_dirs}")
+
+    consolidated_data_deps = generate_data_deps(
+        str(open_trace_log),
+        str(strace_manager),
+        str(strace_worker),
+        data_dirs=resolved_data_dirs,
+        notebook_dir=str(notebook_dir),
+    )
     print("time taken to generate data dep file: ", time.time() - start)
+
+    return {
+        "strace_manager": strace_manager,
+        "strace_worker": strace_worker,
+        "manager_environment_yml": manager_env_yml,
+        "worker_environment_yml": worker_env_yml,
+        "manager_data_dependencies_yml": manager_data_deps_yml,
+        "worker_data_dependencies_yml": worker_data_deps_yml,
+        "consolidated_data_deps": consolidated_data_deps,
+        "notebook_dir": notebook_dir,
+    }

--- a/floability/audit/detect_local_files.py
+++ b/floability/audit/detect_local_files.py
@@ -1,0 +1,73 @@
+"""
+Detect local helper .py files used by a notebook during execution.
+
+Scans strace_manager output for openat calls to .py files that live inside
+the notebook's directory (not conda/system paths).
+"""
+
+import re
+from pathlib import Path
+from typing import List
+
+
+_EXCLUDED_PREFIXES = (
+    "/proc", "/sys", "/usr", "/lib", "/opt", "/tmp", "/var", "/etc",
+)
+_EXCLUDED_SUBSTRINGS = (
+    "site-packages", "__pycache__", ".pyc",
+    "vine-run-info", "ipykernel", "jupyter",
+)
+
+
+def _is_local_helper(path: str, notebook_dir: Path) -> bool:
+    """Return True if path is a .py file inside notebook_dir, not a system file."""
+    if not path.endswith(".py"):
+        return False
+    if any(path.startswith(p) for p in _EXCLUDED_PREFIXES):
+        return False
+    if any(s in path for s in _EXCLUDED_SUBSTRINGS):
+        return False
+    try:
+        p = Path(path)
+        p.relative_to(notebook_dir)
+        return True
+    except ValueError:
+        return False
+
+
+def detect_local_py_files(strace_manager: str, notebook_path: str) -> List[Path]:
+    """
+    Return local helper .py files opened during notebook execution.
+
+    Args:
+        strace_manager: Path to strace output from jupyter execute run.
+        notebook_path: Path to the notebook (.ipynb).
+
+    Returns:
+        List of absolute Paths to local .py helper files (deduplicated, exist on disk).
+    """
+    notebook_dir = Path(notebook_path).resolve().parent
+    found = []
+    seen = set()
+
+    try:
+        with open(strace_manager, "r") as f:
+            for line in f:
+                if "openat" not in line:
+                    continue
+                m = re.search(r'"([^"]+)"', line)
+                if not m:
+                    continue
+                path = m.group(1)
+                if path in seen:
+                    continue
+                if not _is_local_helper(path, notebook_dir):
+                    continue
+                p = Path(path)
+                if p.is_file():
+                    found.append(p)
+                    seen.add(path)
+    except FileNotFoundError:
+        print(f"[floability] Warning: strace file not found: {strace_manager}")
+
+    return found

--- a/floability/audit/generate_backpack.py
+++ b/floability/audit/generate_backpack.py
@@ -1,0 +1,204 @@
+"""
+Generate a complete floability backpack structure from audit outputs.
+
+Creates:
+  <backpack_name>/
+  ├── workflow/           notebook + local helper .py files
+  ├── software/
+  │   └── environment.yml (from manager_environment.yml produced by audit)
+  ├── compute/
+  │   └── compute.yml     (from bootstrap template)
+  └── data/               (when data deps are provided)
+      ├── data.yml
+      └── <data files copied from audit machine>
+"""
+
+import hashlib
+import shutil
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import yaml
+
+
+def _load_template_compute() -> dict:
+    """Load compute.yml from bootstrap templates."""
+    template_dir = Path(__file__).parent.parent / "bootstrap_templates"
+    compute_file = template_dir / "compute.yml"
+    with open(compute_file) as f:
+        return yaml.safe_load(f) or {}
+
+
+def _sha256(file_path: Path) -> str:
+    h = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _safe_name(rel_path: str) -> str:
+    """Derive a data entry name from a relative path."""
+    return rel_path.replace("/", "_").replace(".", "_").strip("_")
+
+
+def generate_data_yml(
+    backpack_path: Path,
+    consolidated_data_deps: Dict[str, Union[int, str]],
+    notebook_dir: Path,
+) -> None:
+    """
+    Build data/data.yml and copy data files into the backpack.
+
+    Each detected data file is copied from its audit-time absolute path into
+    backpack/data/<rel_path>, where rel_path is the path relative to notebook_dir.
+    The data.yml entry uses source_type: backpack with matching source and
+    target_location fields.
+
+    Args:
+        backpack_path: Root of the backpack being created.
+        consolidated_data_deps: {abs_path: size} from audit (union of manager + worker).
+        notebook_dir: Absolute path to the directory containing the notebook.
+                      Used to compute rel_path for each file.
+    """
+    data_dir = backpack_path / "data"
+    data_dir.mkdir(exist_ok=True)
+
+    entries = []
+    for abs_path, size in consolidated_data_deps.items():
+        src = Path(abs_path)
+        if not src.is_file():
+            print(f"[floability]   Warning: data file not found, skipping: {abs_path}")
+            continue
+
+        try:
+            rel_path = src.relative_to(notebook_dir)
+        except ValueError:
+            # file not under notebook_dir — use basename only as rel_path
+            rel_path = Path(src.name)
+            print(f"[floability]   Warning: {src.name} outside notebook dir, placing under data/")
+
+        rel_str = rel_path.as_posix()
+
+        # Always store files under backpack/data/ for cleanliness.
+        # If rel_path already starts with data/, copy directly (avoids data/data/).
+        # Otherwise prepend data/ to the backpack-side source path.
+        if rel_str.startswith("data/"):
+            source_str = rel_str
+            dest = backpack_path / rel_path
+        else:
+            source_str = "data/" + rel_str
+            dest = backpack_path / "data" / rel_path
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+
+        checksum = _sha256(dest)
+
+        entry = {
+            "name": _safe_name(rel_str),
+            "source_type": "backpack",
+            "source": source_str,
+            "target_location": rel_str,
+        }
+        if isinstance(size, int):
+            entry["expected_size"] = size
+        entry["checksum"] = f"sha256:{checksum}"
+
+        entries.append(entry)
+        print(f"[floability]   Added data file: {rel_str} ({size} bytes)")
+
+    data_yml = {
+        "schema_version": 1.0,
+        "default_profile": "local_data",
+        "profiles": {
+            "local_data": {
+                "policy": {
+                    "retry_attempts": 0,
+                    "timeout": 30,
+                    "size_tolerance_bytes": 10,
+                },
+                "data": entries,
+            }
+        },
+    }
+
+    data_yml_path = data_dir / "data.yml"
+    with open(data_yml_path, "w") as f:
+        yaml.safe_dump(data_yml, f, default_flow_style=False, sort_keys=False)
+
+    print(f"[floability]   Generated data/data.yml with {len(entries)} file(s)")
+
+
+def generate_backpack(
+    backpack_name: str,
+    notebook_path: str,
+    manager_env_yml: str,
+    local_helper_files: List[Path],
+    output_dir: Optional[str] = None,
+    force: bool = False,
+    consolidated_data_deps: Optional[Dict[str, Union[int, str]]] = None,
+    notebook_dir: Optional[Path] = None,
+) -> Path:
+    """
+    Build a backpack directory from audit outputs.
+
+    Args:
+        backpack_name: Name for the backpack (also the directory name).
+        notebook_path: Absolute path to the source notebook.
+        manager_env_yml: Path to manager_environment.yml produced by audit.
+        local_helper_files: Local .py files detected from strace (go into workflow/).
+        output_dir: Where to create the backpack directory. Defaults to CWD.
+        force: Overwrite existing backpack directory.
+        consolidated_data_deps: {abs_path: size} union of manager+worker data files.
+                                 When provided, generates data/data.yml.
+        notebook_dir: Absolute path to notebook directory. Required when
+                      consolidated_data_deps is provided.
+
+    Returns:
+        Path to the created backpack directory.
+    """
+    base = Path(output_dir).resolve() if output_dir else Path.cwd()
+    backpack_path = base / backpack_name
+
+    if backpack_path.exists():
+        if force:
+            print(f"[floability] Removing existing backpack at {backpack_path}")
+            shutil.rmtree(backpack_path)
+        else:
+            raise ValueError(
+                f"Backpack directory already exists: {backpack_path}\n"
+                "Use --force to overwrite."
+            )
+
+    # Create structure
+    (backpack_path / "workflow").mkdir(parents=True)
+    (backpack_path / "software").mkdir()
+    (backpack_path / "compute").mkdir()
+
+    # --- workflow/ ---
+    nb = Path(notebook_path).resolve()
+    shutil.copy2(nb, backpack_path / "workflow" / nb.name)
+
+    for helper in local_helper_files:
+        dest = backpack_path / "workflow" / helper.name
+        shutil.copy2(helper, dest)
+        print(f"[floability]   Copied helper: {helper.name}")
+
+    # --- software/environment.yml ---
+    env_src = Path(manager_env_yml)
+    if env_src.is_file():
+        shutil.copy2(env_src, backpack_path / "software" / "environment.yml")
+    else:
+        print(f"[floability] Warning: manager_environment.yml not found at {env_src}")
+
+    # --- compute/compute.yml ---
+    compute_dict = _load_template_compute()
+    with open(backpack_path / "compute" / "compute.yml", "w") as f:
+        yaml.safe_dump(compute_dict, f, default_flow_style=False, sort_keys=False)
+
+    # --- data/ ---
+    if consolidated_data_deps and notebook_dir:
+        generate_data_yml(backpack_path, consolidated_data_deps, notebook_dir)
+
+    return backpack_path

--- a/floability/audit/generate_data_deps.py
+++ b/floability/audit/generate_data_deps.py
@@ -1,43 +1,94 @@
+import re
 import sys
 import os
-import re
+from pathlib import Path
+from typing import List, Optional, Set, Dict
+
 import yaml
 
 
-def process_strace_log(file_path, data_dep_list):
-    deps = []
-    seen = set()
+def scan_strace_for_data_files(
+    strace_file: str,
+    data_dir_prefixes: List[str],
+    notebook_dir: Optional[str] = None,
+) -> Set[str]:
+    """
+    Scan a strace log for openat calls under any of the given directory prefixes.
 
+    Strace records paths exactly as passed to the syscall — both absolute and
+    relative paths may appear. Relative paths are resolved against notebook_dir
+    (the directory the notebook ran from) before prefix-matching.
+
+    Args:
+        strace_file: Path to strace output file.
+        data_dir_prefixes: List of absolute directory paths to filter by.
+        notebook_dir: Directory the notebook executed from, used to resolve
+                      relative paths found in strace output.
+
+    Returns:
+        Set of absolute file paths that were opened under those directories.
+    """
+    found: Set[str] = set()
+    nb_dir = Path(notebook_dir).resolve() if notebook_dir else None
+
+    try:
+        with open(strace_file, "r") as f:
+            for line in f:
+                if "openat" not in line:
+                    continue
+                m = re.search(r'"([^"]+)"', line)
+                if not m:
+                    continue
+                path = m.group(1)
+
+                # Resolve relative paths using notebook_dir
+                # Skip files opened for writing (output/runtime artifacts, not input data)
+                if any(flag in line for flag in ("O_WRONLY", "O_CREAT", "O_TRUNC")):
+                    continue
+
+                if not path.startswith("/"):
+                    if nb_dir is None:
+                        continue
+                    abs_path = str((nb_dir / path).resolve())
+                else:
+                    abs_path = path
+
+                if any(abs_path.startswith(prefix) for prefix in data_dir_prefixes):
+                    found.add(abs_path)
+    except FileNotFoundError:
+        print(f"Error: File '{strace_file}' not found")
+    except Exception as e:
+        print(f"Error scanning strace file: {e}")
+    return found
+
+
+def process_strace_log(file_path: str, data_dep_list: List[str]) -> Set[str]:
+    """Filter strace openat calls to only those matching data_dep_list (exact path match)."""
+    seen: Set[str] = set()
     try:
         with open(file_path, "r") as file:
             for line in file:
                 if "openat" not in line:
                     continue
-
                 start = line.index('"') + 1
                 end = line.index('"', start)
                 full_path = line[start:end].strip()
-
-                # check if path is in data_dep_list
                 if not any(dep == full_path for dep in data_dep_list):
                     continue
-                # check if path is in seen
                 if full_path in seen:
                     continue
                 seen.add(full_path)
-        return seen
     except FileNotFoundError:
         print(f"Error: File '{file_path}' not found")
-        return set()
     except Exception as e:
-        print(f"Error processing file: {str(e)}")
-        return set()
+        print(f"Error processing file: {e}")
+    return seen
 
 
-def get_list_of_files(file_path):
-    # Read the list of files from the file
+def get_list_of_files(file_path: str) -> List[str]:
+    """Read data file list from open_trace.log, filtering out system/infra paths."""
     excluded_paths = ["/proc", "/sys", "/usr", "/lib", "/opt", "/tmp", "/var", "/etc"]
-    excluded_paths_contains = [
+    excluded_substrings = [
         "/site-packages",
         "/vine-run-info",
         "/open_trace.log",
@@ -45,114 +96,129 @@ def get_list_of_files(file_path):
     ]
     with open(file_path, "r") as f:
         lines = f.readlines()
-        lines = [line.strip() for line in lines]
-        lines = [
-            line
-            for line in lines
-            if not any(line.startswith(excluded) for excluded in excluded_paths)
-        ]
-        lines = [
-            line
-            for line in lines
-            if not any(excluded in line for excluded in excluded_paths_contains)
-        ]
-
+    lines = [line.strip() for line in lines]
+    lines = [l for l in lines if not any(l.startswith(p) for p in excluded_paths)]
+    lines = [l for l in lines if not any(s in l for s in excluded_substrings)]
     return lines
 
 
-def extract_file_sizes(log_file_name, target_file_list):
+def extract_file_sizes(log_file_name: str, target_file_list) -> Dict[str, int]:
     """
-    This function extracts the file sizes for the necessary files.
-    Input: name of the strace log file, and a list of the files.
-    Output: a dictionary with file name: file size pairs.
+    Extract file sizes for target files from a strace log.
 
+    Args:
+        log_file_name: Path to strace output file.
+        target_file_list: Collection of absolute file paths to look up.
+
+    Returns:
+        Dict mapping file path to size in bytes (or "Unknown").
     """
     target_paths = set(item.strip() for item in target_file_list if item.strip())
+    if not target_paths:
+        return {}
 
-    def path_matches_target(opened_path):
-        # This function checks the matching of target files with the opened files
-        return any(opened_path.endswith(target) for target in target_paths)
+    def resolve_target(opened_path: str) -> Optional[str]:
+        """Return the absolute target path that matches opened_path, or None."""
+        # Strip leading './' so './data/file.csv' matches against absolute targets
+        normalized = opened_path[2:] if opened_path.startswith("./") else opened_path
+        for target in target_paths:
+            if opened_path.endswith(target) or target.endswith(normalized):
+                return target
+        return None
 
     open_files = []
 
-    # Explore the strace log
     with open(log_file_name, "r") as f:
         for line in f:
-            # Match PID
             pid_match = re.match(r"^\s*(\d+)", line)
             if not pid_match:
                 continue
             pid = int(pid_match.group(1))
-            # Match opened files
+
             open_match = re.search(r'openat\(.*?"(.*?)".*?= (\d+)', line)
             if open_match:
                 path, fd = open_match.groups()
-                if path_matches_target(path):
+                matched = resolve_target(path)
+                if matched:
                     open_files.append(
-                        {"pid": pid, "fd": int(fd), "path": path, "size": "Unknown"}
+                        {"pid": pid, "fd": int(fd), "path": matched, "size": "Unknown"}
                     )
-            # Match file descriptor from fstat
+
             fstat_match = re.search(r"fstat\((\d+), \{.*?st_size=(\d+)", line)
             if fstat_match:
                 fd, size = map(int, fstat_match.groups())
                 for entry in reversed(open_files):
-                    if (
-                        entry["pid"] == pid
-                        and entry["fd"] == fd
-                        and entry["size"] == "Unknown"
-                    ):
+                    if entry["pid"] == pid and entry["fd"] == fd and entry["size"] == "Unknown":
                         entry["size"] = size
                         break
-            # Match file descriptor from nfstat
+
             nfstat_match = re.search(r'newfstatat\((\d+), "", \{.*?st_size=(\d+)', line)
             if nfstat_match:
                 fd, size = map(int, nfstat_match.groups())
                 for entry in reversed(open_files):
-                    if (
-                        entry["pid"] == pid
-                        and entry["fd"] == fd
-                        and entry["size"] == "Unknown"
-                    ):
+                    if entry["pid"] == pid and entry["fd"] == fd and entry["size"] == "Unknown":
                         entry["size"] = size
                         break
 
-    # Deduplicate
-    unique_files = {}
+    unique_files: Dict[str, int] = {}
     for entry in open_files:
         path = entry["path"]
         size = entry["size"]
-        if path not in unique_files or (
-            unique_files[path] == "Unknown" and size != "Unknown"
-        ):
+        if path not in unique_files or (unique_files[path] == "Unknown" and size != "Unknown"):
             unique_files[path] = size
 
     return unique_files
 
 
-def main(file_path, strace_manager, strace_worker):
-    # Get the list of data dependencies from the open_trace.log file
+def main(
+    open_trace_log: str,
+    strace_manager: str,
+    strace_worker: str,
+    data_dirs: Optional[List[str]] = None,
+    notebook_dir: Optional[str] = None,
+) -> Dict[str, int]:
+    """
+    Detect data dependencies and write manager/worker YAML files.
 
-    data_dep_list = get_list_of_files(file_path)
+    Args:
+        open_trace_log: Path to open_trace.log from injected notebook cell.
+        strace_manager: Path to manager strace output.
+        strace_worker: Path to worker strace output.
+        data_dirs: Optional list of absolute directory paths. When provided,
+                   strace is scanned directly for files under those directories
+                   (catches worker-only files missed by open_trace.log).
+                   When None, falls back to open_trace.log-gated detection.
 
-    # Process the strace logs for manager and worker
-    manager_list = process_strace_log(strace_manager, data_dep_list)
-    worker_list = process_strace_log(strace_worker, data_dep_list)
+    Returns:
+        Consolidated dict mapping absolute file path to size in bytes (or "Unknown"),
+        combining manager and worker dependencies (union, worker fills gaps).
+    """
+    if data_dirs:
+        manager_files = scan_strace_for_data_files(strace_manager, data_dirs, notebook_dir)
+        worker_files = scan_strace_for_data_files(strace_worker, data_dirs, notebook_dir)
+    else:
+        data_dep_list = get_list_of_files(open_trace_log)
+        manager_files = process_strace_log(strace_manager, data_dep_list)
+        worker_files = process_strace_log(strace_worker, data_dep_list)
 
-    # Extract file sizes
-    manager_list_with_size = extract_file_sizes(strace_manager, manager_list)
-    worker_list_with_size = extract_file_sizes(strace_worker, worker_list)
-    # Write manager dependencies to a file
+    manager_list_with_size = extract_file_sizes(strace_manager, manager_files)
+    worker_list_with_size = extract_file_sizes(strace_worker, worker_files)
+
     manager_dependencies = [
         {"name": path, "size": size} for path, size in manager_list_with_size.items()
     ]
-    manager_dependencies_yml = {"data_dependencies": manager_dependencies}
     with open("manager_data_dependencies.yml", "w") as f:
-        yaml.dump(manager_dependencies_yml, f, sort_keys=False)
+        yaml.dump({"data_dependencies": manager_dependencies}, f, sort_keys=False)
 
-    # Write worker dependencies to a file
     worker_dependencies = [
         {"name": path, "size": size} for path, size in worker_list_with_size.items()
     ]
-    worker_dependencies_yml = {"data_dependencies": worker_dependencies}
     with open("worker_data_dependencies.yml", "w") as f:
-        yaml.dump(worker_dependencies_yml, f, sort_keys=False)
+        yaml.dump({"data_dependencies": worker_dependencies}, f, sort_keys=False)
+
+    consolidated: Dict[str, int] = dict(manager_list_with_size)
+    for path, size in worker_list_with_size.items():
+        if path not in consolidated or consolidated[path] == "Unknown":
+            consolidated[path] = size
+
+    return consolidated

--- a/floability/audit/generate_requirements.py
+++ b/floability/audit/generate_requirements.py
@@ -5,23 +5,34 @@ import yaml
 
 
 # Function to process strace log file and extract package information
-def process_strace_log(file_path):
-    manager_packages = []  # List to store package information
-    seen_manager = set()  # Set to track already processed packages
+def process_strace_log(file_path, conda_env_prefix=None):
+    """
+    Extract package information from a strace log.
+
+    Args:
+        file_path: Path to strace log.
+        conda_env_prefix: When provided, only consider site-packages paths
+                          under this prefix. Filters out base-conda and other
+                          env packages that appear because strace -f follows
+                          the 'conda run' wrapper process.
+    """
+    manager_packages = []
+    seen_manager = set()
 
     try:
-        # Open the strace log file for reading
         with open(file_path, "r") as file:
             for line in file:
-                # Skip lines that don't contain 'openat' or 'site-packages'
                 if "openat" not in line or "site-packages" not in line:
                     continue
 
                 try:
-                    # Extract the full path from the line
                     start = line.index('"') + 1
                     end = line.index('"', start)
                     full_path = line[start:end]
+
+                    if conda_env_prefix and not full_path.startswith(conda_env_prefix):
+                        continue
+
                     path_parts = full_path.split("/")
 
                     try:
@@ -72,10 +83,10 @@ def process_strace_log(file_path):
 
     except FileNotFoundError:
         print(f"Error: File '{file_path}' not found")
-        return [], []
+        return []
     except Exception as e:
         print(f"Error processing file: {str(e)}")
-        return [], []
+        return []
 
 
 # Function to find the version of a package from its directory
@@ -191,12 +202,11 @@ def generate_requirements_txt(
 
 
 # Main function to process log files and generate requirements
-def main(manager_log_file, worker_log_file):
-    manager_packages = process_strace_log(manager_log_file)
-    worker_packages = process_strace_log(worker_log_file)
+def main(manager_log_file, worker_log_file, conda_env_prefix=None):
+    manager_packages = process_strace_log(manager_log_file, conda_env_prefix)
+    worker_packages = process_strace_log(worker_log_file, conda_env_prefix)
 
     if manager_packages or worker_packages:
-        # Generate requirements files
         generate_requirements_txt(manager_packages, worker_packages)
     else:
         print("No packages found or error occurred")

--- a/floability/audit/generate_verified_env_yaml.py
+++ b/floability/audit/generate_verified_env_yaml.py
@@ -120,12 +120,20 @@ def get_installed_packages_pip():
     return installed
 
 
-def get_installed_packages_conda():
-    """Gets installed packages using conda list."""
+def get_installed_packages_conda(prefix=None):
+    """Gets installed packages using conda list.
+
+    Args:
+        prefix: Path to conda environment prefix to query. When None, queries
+                the currently active environment.
+    """
     installed = {}
+    cmd = ["conda", "list", "--json"]
+    if prefix:
+        cmd += ["--prefix", prefix]
     try:
         result = subprocess.run(
-            ["conda", "list", "--json"],
+            cmd,
             capture_output=True,
             text=True,
             check=True,
@@ -213,7 +221,7 @@ def normalize_req_line(line):
 # --- Main Logic ---
 
 
-def main(requirements_file, output="environment.yaml", env_name="reconstructed-env"):
+def main(requirements_file, output="environment.yaml", env_name="reconstructed-env", conda_prefix=None):
 
     req_file_path = pathlib.Path(requirements_file)
     output_file_path = pathlib.Path(output)
@@ -223,21 +231,25 @@ def main(requirements_file, output="environment.yaml", env_name="reconstructed-e
         sys.exit(1)
 
     print(f"Step 1: Determining active environment type...")
-    env_type, active_prefix = get_environment_type()
-    print(f"--> Active environment type: {env_type}")
-    print(f"--> Active Python prefix: {active_prefix}")
+    if conda_prefix:
+        # Target env is always conda when explicitly specified
+        env_type = "conda"
+        print(f"--> Using specified conda env: {conda_prefix}")
+    else:
+        env_type, active_prefix = get_environment_type()
+        print(f"--> Active environment type: {env_type}")
+        print(f"--> Active Python prefix: {active_prefix}")
 
     if env_type == "unknown":
         print(
             "Warning: Could not reliably determine environment type. Assuming 'pip'-based workflow."
         )
-        # Default to pip behavior if unsure
-        env_type = "venv"  # Treat unknown as venv for package gathering
+        env_type = "venv"
 
-    print(f"\nStep 2: Getting installed packages from active {env_type} environment...")
+    print(f"\nStep 2: Getting installed packages from {conda_prefix or 'active'} environment...")
     if env_type == "conda":
-        installed_packages = get_installed_packages_conda()
-    else:  # venv or unknown treated as venv
+        installed_packages = get_installed_packages_conda(prefix=conda_prefix)
+    else:
         installed_packages = get_installed_packages_pip()
 
     if not installed_packages:
@@ -320,11 +332,10 @@ def main(requirements_file, output="environment.yaml", env_name="reconstructed-e
                 f"  \n**[Not Found]:** {norm_req_name} (Not found in the list of currently installed packages)\n"
             )
 
-    # Add python version
-    python_version = platform.python_version()
-    conda_deps.insert(
-        0, f"python=={python_version}"
-    )  # Add python itself as a dependency
+    # Get Python version from the queried package list so it matches the target env
+    python_pkg = installed_packages.get("python")
+    python_version = python_pkg["version"] if python_pkg else platform.python_version()
+    conda_deps.insert(0, f"python=={python_version}")
     print(f"\nAdded Python dependency: python=={python_version}")
 
     # Ensure pip is included if there are pip dependencies

--- a/floability/commands/audit.py
+++ b/floability/commands/audit.py
@@ -47,6 +47,53 @@ class AuditCommand(BaseCommand):
             action="store_true",
             help="Generate dependencies at the cell level instead of notebook level",
         )
+        parser.add_argument(
+            "--conda-env",
+            required=False,
+            default=None,
+            help=(
+                "Path to a conda environment prefix to use when executing the notebook "
+                "(e.g. /shared/miniconda3/envs/my-env). The notebook's dependencies "
+                "must be installed in this environment."
+            ),
+        )
+        parser.add_argument(
+            "--backpack-name",
+            required=False,
+            default=None,
+            help=(
+                "If provided, generate a complete backpack directory with this name "
+                "in the current directory. Creates workflow/, software/, and compute/ "
+                "from audit outputs."
+            ),
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            default=False,
+            help="Overwrite existing backpack directory if it exists (only used with --backpack-name).",
+        )
+        parser.add_argument(
+            "--no-worker",
+            action="store_true",
+            default=False,
+            help=(
+                "Skip starting a vine_worker during audit. Use for non-distributed "
+                "notebooks that do not use TaskVine."
+            ),
+        )
+        parser.add_argument(
+            "--data-dirs",
+            nargs="+",
+            default=None,
+            metavar="PATH",
+            help=(
+                "One or more directories containing data files accessed by the notebook "
+                "(e.g. --data-dirs ./data ./inputs). Paths relative to the notebook "
+                "directory or absolute. Used to detect data dependencies directly from "
+                "strace output instead of relying on Python-level open() tracing."
+            ),
+        )
 
     def execute(self, args: argparse.Namespace, cleanup_manager=None) -> None:
         """Execute audit command."""
@@ -60,4 +107,9 @@ class AuditCommand(BaseCommand):
         return [
             "floability audit --notebook example/matrix-multiplication/workflow/matrix-multiplication.ipynb",
             "floability audit --notebook mynotebook.ipynb --cell-level",
+            "floability audit --notebook mynotebook.ipynb --conda-env /path/to/conda/env",
+            "floability audit --notebook mynotebook.ipynb --backpack-name my-workflow",
+            "floability audit --notebook mynotebook.ipynb --conda-env /path/to/conda/env --backpack-name my-workflow --force",
+            "floability audit --notebook mynotebook.ipynb --data-dirs ./data ./inputs --backpack-name my-workflow",
+            "floability audit --notebook mynotebook.ipynb --no-worker --conda-env /path/to/env --backpack-name my-workflow",
         ]

--- a/floability/ops/audit.py
+++ b/floability/ops/audit.py
@@ -4,18 +4,76 @@ Audit operations for Floability CLI.
 
 from ..audit.audit import audit
 from ..audit.cell_level.audit import audit as cell_level_audit
+from ..audit.detect_local_files import detect_local_py_files
+from ..audit.generate_backpack import generate_backpack
 
 
 def run_audit_command(args):
     if not args.notebook:
         print("[floability] 'audit' command requires --notebook argument.")
         return
+
     print(
         f"[floability] Generating environment for notebook: {args.notebook} with kernel: {args.kernel}"
     )
+
     if args.cell_level:
         cell_level_audit(
             args.notebook, args.kernel, args.manager_name, args.manager_port
         )
+        return
+
+    result = audit(
+        args.notebook,
+        args.kernel,
+        args.manager_name,
+        args.manager_port,
+        conda_env=getattr(args, "conda_env", None),
+        data_dirs=getattr(args, "data_dirs", None),
+        no_worker=getattr(args, "no_worker", False),
+    )
+
+    backpack_name = getattr(args, "backpack_name", None)
+    if not backpack_name or not result:
+        return
+
+    print(f"\n[floability] Generating backpack: {backpack_name}")
+
+    helpers = detect_local_py_files(
+        strace_manager=str(result["strace_manager"]),
+        notebook_path=args.notebook,
+    )
+    if helpers:
+        print(f"[floability] Detected {len(helpers)} local helper file(s):")
+        for h in helpers:
+            print(f"[floability]   {h.name}")
     else:
-        audit(args.notebook, args.kernel, args.manager_name, args.manager_port)
+        print("[floability] No local helper files detected.")
+
+    consolidated_data_deps = result.get("consolidated_data_deps")
+    notebook_dir = result.get("notebook_dir")
+
+    has_data = bool(consolidated_data_deps)
+
+    try:
+        backpack_path = generate_backpack(
+            backpack_name=backpack_name,
+            notebook_path=args.notebook,
+            manager_env_yml=str(result["manager_environment_yml"]),
+            local_helper_files=helpers,
+            force=getattr(args, "force", False),
+            consolidated_data_deps=consolidated_data_deps,
+            notebook_dir=notebook_dir,
+        )
+        print(f"\n[floability] Backpack created: {backpack_path}")
+        print(f"[floability]   workflow/  — notebook + {len(helpers)} helper(s)")
+        print(f"[floability]   software/environment.yml — from audit")
+        print(f"[floability]   compute/compute.yml — default template (edit before running)")
+        if has_data:
+            print(f"[floability]   data/data.yml — {len(consolidated_data_deps)} file(s) bundled")
+        print(f"\n[floability] Next steps:")
+        print(f"[floability]   1. Review compute/compute.yml and adjust worker resources")
+        print(f"[floability]   2. floability backpack validate {backpack_path}")
+        print(f"[floability]   3. floability run --backpack {backpack_path}")
+    except ValueError as e:
+        print(f"[floability] Error: {e}")


### PR DESCRIPTION
Extends floability audit to generate a complete backpack structure directly from a notebook execution. A new --backpack-name flag triggers creation of workflow/, software/environment.yml, compute/compute.yml, and data/data.yml (with bundled data files) from a single command.

New flags: --backpack-name, --conda-env (run notebook in a specified conda env), --data-dirs (detect data dependencies from strace by directory prefix), --no-worker (skip vine worker for non-distributed notebooks).